### PR TITLE
Expose SolarAndStorage from the package root

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Import the packages
 ```python
 import numpy as np
 
-from solar_and_storage.solar_and_storage import SolarAndStorage
+from solar_and_storage import SolarAndStorage
 
 ```
 Make the fake price and solar data

--- a/examples/battery_only.py
+++ b/examples/battery_only.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from solar_and_storage.solar_and_storage import SolarAndStorage
+from solar_and_storage import SolarAndStorage
 from solar_and_storage.example import prices, no_solar
 
 HTML_OUTPUT = "" # set path or empty will skip writing HTML

--- a/examples/battery_solar.py
+++ b/examples/battery_solar.py
@@ -3,7 +3,7 @@
 import numpy as np
 import os
 
-from solar_and_storage.solar_and_storage import SolarAndStorage
+from solar_and_storage import SolarAndStorage
 from solar_and_storage.example import prices, with_solar
 
 HTML_OUTPUT = "" # set path or empty will skip writing HTML

--- a/solar_and_storage/__init__.py
+++ b/solar_and_storage/__init__.py
@@ -1,1 +1,5 @@
-# noqa
+"""Public package API for solar_and_storage."""
+
+from solar_and_storage.solar_and_storage import SolarAndStorage
+
+__all__ = ["SolarAndStorage"]

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1,6 +1,11 @@
 import numpy as np
 
-from solar_and_storage.solar_and_storage import SolarAndStorage
+from solar_and_storage import SolarAndStorage
+from solar_and_storage.solar_and_storage import SolarAndStorage as SolarAndStorageImpl
+
+
+def test_package_exports_solar_and_storage():
+    assert SolarAndStorage is SolarAndStorageImpl
 
 
 def test_solar_and_storage():


### PR DESCRIPTION
## Summary
- Export `SolarAndStorage` from `solar_and_storage.__init__` and define the package-level public API with `__all__`.
- Update the README and examples to use `from solar_and_storage import SolarAndStorage` instead of the internal module path.
- Add regression coverage that the package-root export resolves to the existing implementation class.

## Checks
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m compileall -q solar_and_storage tests examples`
- `examples/battery_only.py` and `examples/battery_solar.py` executed with Plotly display/image output suppressed
- Package-root import checked from `/tmp` through the existing editable install
- `git diff --check`

Part of #14.
