### PR TITLE
updated README with uv change

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ The model uses variable prices and a solar generation profile.
 pip install solar-and-storage
 ```
 
+## Development
+This repository uses [uv](https://docs.astral.sh/uv/) for local development and CI (`pyproject.toml` + `uv.lock`).
+
+```
+uv sync
+uv run pytest src/tests
+uv run ruff check .
+```
+
 
 ## Example
 


### PR DESCRIPTION
## Description

### Summary
Added a Development section to the README documenting uv-based local setup after the OCF CI/packaging migration (#20).

Keeps `pip install solar-and-storage` for end users, and adds contributor commands:
```
uv sync
uv run pytest src/tests
uv run ruff check .
```

### Motivation
#20 introduced `pyproject.toml` + `uv.lock` and uv-based CI, but the README still only showed `pip install`. This helps contributors match the local workflow used in CI.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
